### PR TITLE
Correct module name from 'Radiodns' to 'RadioDNS' to match main class

### DIFF
--- a/lib/radiodns/version.rb
+++ b/lib/radiodns/version.rb
@@ -1,3 +1,3 @@
-module Radiodns
+module RadioDNS
   VERSION = "0.1.3"
 end

--- a/radiodns.gemspec
+++ b/radiodns.gemspec
@@ -4,7 +4,7 @@ require "radiodns/version"
 
 Gem::Specification.new do |s|
   s.name        = "radiodns"
-  s.version     = Radiodns::VERSION
+  s.version     = RadioDNS::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Chris Lowis"]
   s.email       = ["chris.lowis@gmail.com"]


### PR DESCRIPTION
Module was called 'RadioDNS' in the main class but 'Radiodns' in the VERSION file
