### PR TITLE
Added support for alternate root domains

### DIFF
--- a/lib/radiodns/resolver.rb
+++ b/lib/radiodns/resolver.rb
@@ -1,54 +1,62 @@
 require 'resolv'
 
 class RadioDNS::Resolver
-  def self.resolve(fqdn)
-    if fqdn.is_a? Hash
-      fqdn = construct_fqdn(fqdn)
+  @root_domain = 'radiodns.org'
+
+  class << self
+    attr_accessor :root_domain
+
+    def resolve(fqdn)
+      if fqdn.is_a? Hash
+        fqdn = construct_fqdn(fqdn)
+      end
+
+      resolver = Resolv::DNS.new
+      cname = resolver.getresource(fqdn, Resolv::DNS::Resource::IN::CNAME)
+      RadioDNS::Service.new(cname.name.to_s)
     end
 
-    resolver = Resolv::DNS.new
-    cname = resolver.getresource(fqdn, Resolv::DNS::Resource::IN::CNAME)
-    RadioDNS::Service.new(cname.name.to_s)
-  end
-
-  def self.construct_fqdn(params)
-    bearer = params[:bearer]
-    case bearer
-      when "fm" then construct_fqdn_for_fm(params)
-      when "dab" then construct_fqdn_for_dab(params)
-      when "drm" then construct_fqdn_for_drm_or_amss(params)
-      when "amss" then construct_fqdn_for_drm_or_amss(params)
-      when "hd" then construct_fqdn_for_hd(params)
+    def construct_fqdn(params)
+      bearer = params[:bearer]
+      case bearer
+        when "fm" then construct_fqdn_for_fm(params)
+        when "dab" then construct_fqdn_for_dab(params)
+        when "drm" then construct_fqdn_for_drm_or_amss(params)
+        when "amss" then construct_fqdn_for_drm_or_amss(params)
+        when "hd" then construct_fqdn_for_hd(params)
+      end
     end
-  end
 
-  private
-  def self.construct_fqdn_for_hd(params)
-    raise ArgumentError unless params[:tx] && params[:cc]
-    [params[:tx], params[:cc], 'hd.radiodns.org'].join('.')
-  end
+    private
+    def construct_fqdn_for_hd(params)
+      raise ArgumentError unless params[:tx] && params[:cc]
+      [params[:tx], params[:cc], 'hd', root_domain].join('.')
+    end
 
-  def self.construct_fqdn_for_drm_or_amss(params)
-    raise ArgumentError unless params[:sid]
-    [params[:sid], params[:bearer], 'radiodns.org'].join('.')
-  end
+    def construct_fqdn_for_drm_or_amss(params)
+      raise ArgumentError unless params[:sid]
+      [params[:sid], params[:bearer], root_domain].join('.')
+    end
 
-  def self.construct_fqdn_for_dab(params)
-    raise ArgumentError unless params[:scids] && params[:sid] && params[:eid] && params[:ecc]
-    [params[:appty_uatype] || params[:pa],
-     params[:scids],
-     params[:sid],
-     params[:eid],
-     params[:ecc],
-     'dab.radiodns.org'].reject{|a| a.nil?}.join('.')
-  end
+    def construct_fqdn_for_dab(params)
+      raise ArgumentError unless params[:scids] && params[:sid] && params[:eid] && params[:ecc]
+      [params[:appty_uatype] || params[:pa],
+       params[:scids],
+       params[:sid],
+       params[:eid],
+       params[:ecc],
+       'dab',
+       root_domain].reject{|a| a.nil?}.join('.')
+    end
 
-  def self.construct_fqdn_for_fm(params)
-    raise ArgumentError if params[:ecc] && params[:country]
-    raise ArgumentError if params[:ecc].nil? && params[:country].nil?
-    [params[:freq],
-     params[:pi],
-     params[:ecc] || params[:country],
-     'fm.radiodns.org'].join('.')
+    def construct_fqdn_for_fm(params)
+      raise ArgumentError if params[:ecc] && params[:country]
+      raise ArgumentError if params[:ecc].nil? && params[:country].nil?
+      [params[:freq],
+       params[:pi],
+       params[:ecc] || params[:country],
+       'fm',
+       root_domain].join('.')
+    end
   end
 end

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -176,5 +176,29 @@ describe "RadioDNS::Resolver" do
         assert_raises(ArgumentError) {RadioDNS::Resolver.construct_fqdn(params)}
       end
     end
+    
+    describe "with alternate root domain" do
+      before(:each) do
+        RadioDNS::Resolver.root_domain = 'test.radiodns.org'
+      end
+      
+      after(:each) do
+        RadioDNS::Resolver.root_domain = 'radiodns.org'
+      end
+
+      describe "for FM/VHF bearer" do
+        it "should construct a fqdn when ecc is supplied" do
+          params = {
+            :bearer => 'fm',
+            :ecc => 'ce1',
+            :pi => 'c585',
+            :freq => '09580'
+          }
+          fqdn = RadioDNS::Resolver.construct_fqdn(params)
+          assert_equal '09580.c585.ce1.fm.test.radiodns.org', fqdn
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This is useful for working with the 'test' alternate root at test.radiodns.org.
